### PR TITLE
Adjacent clusters

### DIFF
--- a/Lib/collidoscope/__init__.py
+++ b/Lib/collidoscope/__init__.py
@@ -30,6 +30,9 @@ def _get_sequential_cluster_ids(glyphs):
     return scis
 
 
+_KNOWN_RULES = ["faraway", "marks", "adjacent_clusters", "cursive", "area"]
+
+
 class Collidoscope:
     """Detect collisions between font glyphs"""
 
@@ -76,6 +79,39 @@ class Collidoscope:
             self.get_anchors()
         else:
             self.anchors = {}
+
+
+    def get_rules(self):
+        """Return all rules that are known.
+
+        This can be used to implement a kind of versioning of the interface
+        to collidoscope.
+
+        E.g. if the client wants to be sure that it is running against a
+        version of collidoscope with the new adjacent_clusters rule,
+        the client can just make sure that the adjacent_clusters rule gets
+        "echoed back" or "acknowledged" by this routine.
+
+        In practice, just the existence of this routine accomplishes the
+        same version-detection for this particular adjacent_clusters feature.
+
+        Alternately, we could use whatever the real/official mechanism is
+        for versioning a Python module, presumably a 3-integer dotted SemVer?
+
+        Version: 0.0.6 in collidoscope.egg-info/PKG-INFO?
+
+        But this routine provides something perhaps useful beyond versioning:
+        it can be used to make sure that the rules passed in don't have a typo
+        in them.
+
+        One might imagine enforcing all this in the constructor, e.g.
+        throwing an exception if an unknown rule is passed in.
+
+        But that would prevent a more gentle "use this rule if you have it"
+        semantics for some future rule.
+        """
+        return {rk: rv for rk, rv in self.rules.items() if rk in _KNOWN_RULES}
+
 
     def prep_shaper(self):
         face = hb.Face(self.fontbinary)

--- a/Lib/collidoscope/__init__.py
+++ b/Lib/collidoscope/__init__.py
@@ -267,6 +267,19 @@ class Collidoscope:
                     overlaps = self.find_overlaps(first, second)
                     if overlaps: return overlaps
 
+        if "adjacent_clusters" in self.rules:
+            cluster_id = 0
+            cluster_ids = []
+            for g in glyphs:
+                if g["category"] == "base":
+                    cluster_id += 1
+                cluster_ids.append(cluster_id)
+            for i in range(1,len(glyphs)-1):
+                for j in range(i+1, len(glyphs)):
+                    if cluster_ids[i] - cluster_ids[j] in (-1, 0, 1):
+                        overlaps = self.find_overlaps(glyphs[i], glyphs[j])
+                        if overlaps: return overlaps
+
         if "marks" in self.rules:
             # print("Mark testing")
             for i in range(1,len(glyphs)-1):

--- a/Lib/collidoscope/__init__.py
+++ b/Lib/collidoscope/__init__.py
@@ -274,7 +274,7 @@ class Collidoscope:
                 if g["category"] == "base":
                     cluster_id += 1
                 cluster_ids.append(cluster_id)
-            for i in range(1,len(glyphs)-1):
+            for i in range(0,len(glyphs)-1):
                 for j in range(i+1, len(glyphs)):
                     if cluster_ids[i] - cluster_ids[j] in (-1, 0, 1):
                         overlaps = self.find_overlaps(glyphs[i], glyphs[j])

--- a/Lib/collidoscope/__init__.py
+++ b/Lib/collidoscope/__init__.py
@@ -41,6 +41,8 @@ class Collidoscope:
                 overlap. Mark glyphs are ignored. All collisions are reported.
             marks (boolean): If true, collisions between all pairs of marks in
                 the string are reported.
+            adjacent_clusters (boolean): If true, collisions between all pairs 
+                of glyphs in adjacent clusters are reported.
             cursive (boolean): If true, adjacent glyphs are tested for overlap.
                 Paths containing cursive anchors are allowed to overlap, but
                 collisions between other paths are reported.
@@ -262,7 +264,6 @@ class Collidoscope:
             glyphs = list(reversed(glyphs))
         if "faraway" in self.rules:
             for firstIx, first in enumerate(glyphs):
-                passedBases = 0
                 nonAdjacent = firstIx + 1
                 # print("Considering %i" % firstIx)
                 if first["category"] == "base":

--- a/Lib/collidoscope/__main__.py
+++ b/Lib/collidoscope/__main__.py
@@ -11,6 +11,8 @@ parser.add_argument('--no-faraway', action='store_false', dest="faraway",
                     help="don't check for interactions between non-adjacent glyphs")
 parser.add_argument('--no-marks', action='store_false', dest="marks",
                     help="don't check for interactions between marks")
+parser.add_argument('--no-adjacent-clusters', action='store_false', dest="adjacent_clusters",
+                    help="don't check for interactions between glyphs in adjacent clusters")
 parser.add_argument('--cursive', action='store_true', dest="cursive",
                     help="check for interactions between paths without anchors")
 parser.add_argument('--area', type=int, default=0, dest="area",
@@ -27,6 +29,7 @@ fontfilename = args.input
 
 c = Collidoscope(fontfilename, {
         "faraway": args.faraway,
+        "adjacent_clusters": args.adjacent_clusters,
         "cursive": args.cursive,
         "area":    args.area / 100,
         "marks":   args.marks


### PR DESCRIPTION
This pull request adds a new CCS (collision candidate set): adjacent clusters.

The existing "marks" CCS, by design, only tests for collisions between marks.

The "faraway" CCS tests for some base-to-mark collisions, but only for marks that are far away, i.e. only for marks that don't belong to the base in question. (Judging from the documentation, I'm not sure whether those faraway base-to-mark tests are even intentional, i.e. judging from the documentation, "faraway" seems to have been intended to test base-to-base collisions only.)

The "cursive" CCS and "area" CCS, by design, only consider adjacent glyphs. Of course this includes some base-to-mark tests, but not all.

So the new adjacent clusters CCS fills what is, at least for my needs, and important void in the options.

The new adjacent clusters CCS truly uses the cluster index from the glyph info rather than using the base and/or mark category. I found this was important for my application, which involves fonts that sometimes insert a thin space in the glyph buffer. This thin space is categorized as a base, but fortunately does not introduce a new cluster.