### PR TITLE
Add option to report base/mark collisions

### DIFF
--- a/Lib/collidoscope/__init__.py
+++ b/Lib/collidoscope/__init__.py
@@ -49,6 +49,8 @@ class Collidoscope:
                 the string are reported.
             bases (boolean): If *false*, collisions between all pairs of bases in
                 the string are *ignored*.
+            bases_marks (boolean): If true, collisions between all pairs of bases
+                and marks in the string are reports.
             adjacent_clusters (boolean): If true, collisions between all pairs 
                 of glyphs in adjacent clusters are reported.
             cursive (boolean): If true, adjacent glyphs are tested for overlap.
@@ -354,6 +356,11 @@ class Collidoscope:
         if self.rules.get("marks"):
             if left["category"] == "mark" and right["category"] == "mark":
                 return True
+
+        if self.rules.get("bases_marks"):
+            # If we reached here since left and right are not of the same
+            # category.
+            return True
 
         if self.rules.get("faraway"):
             next_base = left_ix + 1

--- a/Lib/collidoscope/__main__.py
+++ b/Lib/collidoscope/__main__.py
@@ -13,6 +13,8 @@ parser.add_argument('--no-marks', action='store_false', dest="marks",
                     help="don't check for interactions between marks")
 parser.add_argument('--no-bases', action='store_false', dest="bases",
                     help="don't check for interactions between bases")
+parser.add_argument('--no-bases-marks', action='store_false', dest="bases_marks",
+                    help="don't check for interactions between bases and marks")
 parser.add_argument('--no-adjacent-clusters', action='store_false', dest="adjacent_clusters",
                     help="don't check for interactions between glyphs in adjacent clusters")
 parser.add_argument('--cursive', action='store_true', dest="cursive",
@@ -47,7 +49,8 @@ c = Collidoscope(fontfilename, {
         "cursive": args.cursive,
         "area":    args.area / 100,
         "marks":   args.marks,
-        "bases":   args.bases
+        "bases":   args.bases,
+        "bases_marks": args.bases_marks,
     },
     scale_factor = float(args.scale_factor)
 )


### PR DESCRIPTION
Fixes https://github.com/simoncozens/collidoscope/issues/10

Now one case set marks=True, bases=False, and bases_marks=True to report all collisions except base/base.