### PR TITLE
Fix string trimming call when the file argument is used

### DIFF
--- a/Lib/collidoscope/__main__.py
+++ b/Lib/collidoscope/__main__.py
@@ -122,7 +122,7 @@ def gen_texts(codepoints):
 if args.text:
     texts = [args.text]
 elif args.file:
-    texts = [ x.rtrim() for x in args.file.readlines()]
+    texts = [ x.rstrip() for x in args.file.readlines()]
 elif args.range:
     for r in args.range.split(","):
         if "-" in r:


### PR DESCRIPTION
I received an exception when this line is executed. It looks like this should be changed to `rstrip()`